### PR TITLE
Expose the Solver constructor

### DIFF
--- a/SimpleSMT.hs
+++ b/SimpleSMT.hs
@@ -5,10 +5,8 @@
 module SimpleSMT
   (
     -- * Basic Solver Interface
-    Solver
+    Solver(..)
   , newSolver
-  , command
-  , stop
   , ackCommand
   , simpleCommand
   , simpleCommandMaybe


### PR DESCRIPTION
I’d like to be able to create a dummy solver (for testing purposes) that just writes all commands to an `IORef`. Afaict there is nothing particularly internal about the `Solver` constructor (especially given that record accessors are already exposed) but it would ofc also be possible to move it to some `.Internal` module.
