### PR TITLE
Use more accurate lower bound on `base`

### DIFF
--- a/simple-smt.cabal
+++ b/simple-smt.cabal
@@ -15,7 +15,7 @@ extra-source-files:  CHANGES
 library
   exposed-modules:     SimpleSMT
   other-extensions:    Safe, RecordWildCards
-  build-depends:       base >=4.7 && <10,
+  build-depends:       base >=4.8 && <10,
                        process
   default-language:    Haskell2010
 


### PR DESCRIPTION
counter-example for base-4.7:

```
Configuring library for simple-smt-0.9.3..
Preprocessing library for simple-smt-0.9.3..
Building library for simple-smt-0.9.3..
[1 of 1] Compiling SimpleSMT        ( SimpleSMT.hs, /tmp/matrix-worker/1540420558/dist-newstyle/build/x86_64-linux/ghc-7.8.4/simple-smt-0.9.3/build/SimpleSMT.o )

SimpleSMT.hs:192:53: Not in scope: ‘<$>’
```

There's no immediate action required as I've also corrected the metadata on Hackage already for the two affected releases, see

- https://hackage.haskell.org/package/simple-smt-0.9.3/revisions/
- https://hackage.haskell.org/package/simple-smt-0.9.4/revisions/
