### PR TITLE
Expose loadString

### DIFF
--- a/SimpleSMT.hs
+++ b/SimpleSMT.hs
@@ -11,6 +11,7 @@ module SimpleSMT
   , simpleCommand
   , simpleCommandMaybe
   , loadFile
+  , loadString
 
     -- ** S-Expressions
   , SExpr(..)


### PR DESCRIPTION
This function is useful for embedding the contents of a file into my Haskell program and loading it into Z3